### PR TITLE
feat: bump ansible working image to 13.5.0

### DIFF
--- a/configurations/apps/ansible-run/apis/definition.yaml
+++ b/configurations/apps/ansible-run/apis/definition.yaml
@@ -45,7 +45,7 @@ spec:
                 ansibleWorkingImage:
                   type: string
                   description: Ansible working container image
-                  default: ghcr.io/stuttgart-things/sthings-ansible:11.11.0
+                  default: ghcr.io/stuttgart-things/sthings-ansible:13.5.0
                 createInventory:
                   type: string
                   description: Whether to create an Ansible inventory


### PR DESCRIPTION
## Summary
- Update default `ansibleWorkingImage` from `11.11.0` to `13.5.0` in the ansible-run XRD

## Test plan
- [ ] Run a test AnsibleRun XR against a target host with the new image
- [ ] Verify playbook execution completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)