### PR TITLE
fix(vault-auth): end-to-end tested migration, OpenTofu HCL fix, doc updates

### DIFF
--- a/configurations/bootstrap/vault-auth/README.md
+++ b/configurations/bootstrap/vault-auth/README.md
@@ -21,6 +21,8 @@ kubectl apply -f apis/definition.yaml
 kubectl apply -f apis/composition.yaml
 ```
 
+> **Function names.** The composition references `crossplane-contrib-function-kcl` and `crossplane-contrib-function-auto-ready` — the names that `examples/function.yaml` creates and that `crossplane` CLI / `kubectl crossplane install function` produce by default. If your cluster has these installed under different names (e.g. plain `function-kcl`, which some ad-hoc setups use), either rename your installed `Function` resources to match or patch `apis/composition.yaml` in place.
+
 ## Use
 
 1. Create the Vault token Secret in the same namespace you'll use for the `VaultK8sAuth`:
@@ -80,6 +82,27 @@ If set, the generated Workspace additionally renders a `vault_kubernetes_auth_ba
 | `tokenKey` | | `token` |
 | `disableIssValidation` | | `true` |
 | `disableLocalCaJwt` | | `true` |
+
+#### `backendConfig` prerequisites
+
+The composition's HCL uses the Terraform `kubernetes` provider's `data "kubernetes_secret"` block to read the CA cert and token reviewer JWT at `tofu apply` time. This means:
+
+1. **The referenced Secret must already exist** in the cluster **before** the `VaultK8sAuth` XR is applied. If it's missing, `tofu plan` fails with `Attempt to index null value` (the data source returns a `null` `.data` map for non-existent Secrets rather than erroring out upfront).
+2. **It must be a ServiceAccount token Secret** — since Kubernetes 1.24 these are no longer auto-created. You have to make one explicitly:
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: vault-dev
+     namespace: default
+     annotations:
+       kubernetes.io/service-account.name: vault-auth-reviewer
+   type: kubernetes.io/service-account-token
+   ```
+   (plus the `vault-auth-reviewer` ServiceAccount and a `system:auth-delegator` ClusterRoleBinding for the token-review call to succeed).
+3. **The opentofu provider's pod SA** needs RBAC to read that Secret via the Kubernetes API (since the TF kubernetes provider uses in-cluster config).
+
+For a minimal smoke test, leave `backendConfig` unset on every entry — the Workspace will still create the Vault auth backend and the role, and you can wire up `kubernetes_host` / `kubernetes_ca_cert` / `token_reviewer_jwt` manually in Vault afterwards.
 
 ## Upgrading from the legacy go-templating composition
 

--- a/configurations/bootstrap/vault-auth/apis/composition.yaml
+++ b/configurations/bootstrap/vault-auth/apis/composition.yaml
@@ -15,14 +15,14 @@ spec:
   pipeline:
     - step: vault-auth
       functionRef:
-        name: function-kcl
+        name: crossplane-contrib-function-kcl
       input:
         apiVersion: krm.kcl.dev/v1alpha1
         kind: KCLInput
         metadata:
           name: vault-auth
         spec:
-          source: oci://ghcr.io/stuttgart-things/xplane-vault-auth:0.4.0
+          source: oci://ghcr.io/stuttgart-things/xplane-vault-auth:0.4.1
     - step: automatically-detect-ready-composed-resources
       functionRef:
-        name: function-auto-ready
+        name: crossplane-contrib-function-auto-ready

--- a/configurations/bootstrap/vault-auth/examples/claim.yaml
+++ b/configurations/bootstrap/vault-auth/examples/claim.yaml
@@ -5,10 +5,8 @@ metadata:
   name: vault-auth
   namespace: default
 spec:
-  compositionRef:
-    name: vault-auth
   clusterName: vcluster-tink2
-  vaultAddr: https://vault.demo-infra.sthings-vsphere.labul.sva.de
+  vaultAddr: https://vault.example.com
   skipTlsVerify: true
 
   providerConfigName: default
@@ -19,8 +17,11 @@ spec:
   vaultTokenSecret: vault
   vaultTokenSecretKey: terraform.tfvars
 
-  # Used when any k8sAuths entry has `backendConfig` set.
-  kubernetesHost: https://kubernetes.default.svc:443
+  # Only used when any k8sAuths entry has `backendConfig` set (see note below).
+  # - In-cluster Vault: leave unset (defaults to https://kubernetes.default.svc:443)
+  # - External Vault: set to a URL reachable from Vault's network
+  #   (what `kubectl cluster-info` prints for the cluster you're wiring up)
+  # kubernetesHost: https://kubernetes.default.svc:443
 
   k8sAuths:
     - name: dev
@@ -28,13 +29,18 @@ spec:
       tokenTtl: 3600
       boundServiceAccountNames: ["default"]
       boundServiceAccountNamespaces: ["default"]
-      backendConfig:
-        secretName: vault-dev # pragma: allowlist secret
+      # Optional: renders vault_kubernetes_auth_backend_config via the
+      # kubernetes TF provider's `data "kubernetes_secret"`. The referenced
+      # Secret MUST exist before this XR is applied — it's typically a
+      # ServiceAccount token Secret (with `ca.crt` + `token` keys). If the
+      # Secret is missing, `tofu plan` will fail with
+      # "Attempt to index null value" because the data source returns
+      # a null .data map for non-existent secrets.
+      # See the README "backendConfig prerequisites" section.
+      # backendConfig:
+      #   secretName: vault-dev
     - name: cicd
       tokenPolicies: ["read-all-tektoncd-kvv2"]
       tokenTtl: 3600
       boundServiceAccountNames: ["default"]
-      boundServiceAccountNamespaces: ["tektoncd"]
-      backendConfig:
-        secretName: vault-cicd # pragma: allowlist secret
-        secretNamespace: tektoncd
+      boundServiceAccountNamespaces: ["default"]


### PR DESCRIPTION
## Summary

End-to-end verification of the vault-auth migration surfaced a few issues; this PR addresses them and bumps to the fixed library version.

### Changes

- **Composition**: bumped fn-kcl source to \`xplane-vault-auth:0.4.1\`, which carries the multi-line HCL \`variable\` block fix from stuttgart-things/kcl#33 (OpenTofu's HCL parser rejects single-line blocks with multiple arguments).
- **Composition**: reverted function refs to the upstream-standard names \`crossplane-contrib-function-kcl\` / \`crossplane-contrib-function-auto-ready\`. #67 had shortened them while debugging a kind cluster that had ad-hoc function names; the standard names are what \`examples/function.yaml\` installs and what most clusters use.
- **README**: new "Function names" note explaining the naming discrepancy and how to patch if your cluster uses different names.
- **README**: new "\`backendConfig\` prerequisites" section documenting that the referenced Secret **must exist before** the XR is applied (the TF \`data "kubernetes_secret"\` returns \`null\` for missing Secrets, causing \`tofu plan\` to fail with \`Attempt to index null value\`), how to create a ServiceAccount token Secret on Kubernetes ≥1.24, and the RBAC the provider-opentofu pod needs.
- **examples/claim.yaml**: dropped stale \`spec.compositionRef\` (moved in Crossplane v2), \`backendConfig\` blocks commented out with a pointer to the README, reverted to placeholder vault / k8s URLs for the committed example.

### End-to-end verification

Against Crossplane v2 + provider-opentofu v1.0.3 + function-kcl v0.12.1 on a real k3s cluster:

- \`VaultK8sAuth\` XR reconciles cleanly (\`Synced=True, Ready=True\`)
- Two generated \`Workspace\` CRs reach \`Ready=True\`
- Vault gains \`auth/vcluster-tink2-dev/\` and \`auth/vcluster-tink2-cicd/\` Kubernetes auth backends
- Role under \`auth/vcluster-tink2-dev/role/dev\` shows the expected bound service accounts, token policies, and TTL

\`backendConfig\` path is not yet verified end-to-end — needs pre-existing SA token Secrets (documented in the README). Tracked in #66.

Refs: stuttgart-things/kcl#33, #66

Generated with [Claude Code](https://claude.com/claude-code)