### PR TITLE
feat(vault-config): crossplane v2 namespaced XRD

### DIFF
--- a/configurations/bootstrap/vault-config/apis/composition.yaml
+++ b/configurations/bootstrap/vault-config/apis/composition.yaml
@@ -2,27 +2,28 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: xvault-config-kcl
+  name: vault-config
   labels:
+    crossplane.io/xrd: vaultconfigs.config.stuttgart-things.com
     provider: stuttgart-things
     category: config
     service: vault
 spec:
   compositeTypeRef:
     apiVersion: config.stuttgart-things.com/v1alpha1
-    kind: XVaultConfig
-
+    kind: VaultConfig
   mode: Pipeline
-
   pipeline:
-    - step: vault-config-kcl
+    - step: vault-config
       functionRef:
         name: crossplane-contrib-function-kcl
       input:
         apiVersion: krm.kcl.dev/v1alpha1
-        kind: KCLRun
+        kind: KCLInput
         metadata:
-          name: vault-config-kcl
+          name: vault-config
         spec:
-          source: oci://ghcr.io/stuttgart-things/xplane-vault-config:0.1.0
-          target: Resources
+          source: oci://ghcr.io/stuttgart-things/xplane-vault-config:0.4.0
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: crossplane-contrib-function-auto-ready

--- a/configurations/bootstrap/vault-config/apis/definition.yaml
+++ b/configurations/bootstrap/vault-config/apis/definition.yaml
@@ -1,22 +1,16 @@
 ---
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: xvaultconfigs.config.stuttgart-things.com
+  name: vaultconfigs.config.stuttgart-things.com
 spec:
   group: config.stuttgart-things.com
+  scope: Namespaced
+  defaultCompositeDeletePolicy: Foreground
   names:
-    kind: XVaultConfig
-    plural: xvaultconfigs
-  claimNames:
     kind: VaultConfig
     plural: vaultconfigs
-  defaultCompositionRef:
-    name: xvault-config-kcl
-  connectionSecretKeys:
-    - csi-token
-    - vso-token
-    - eso-token
+    singular: vaultconfig
   versions:
     - name: v1alpha1
       served: true
@@ -28,7 +22,6 @@ spec:
             spec:
               type: object
               properties:
-                # Basic Configuration
                 name:
                   type: string
                   description: "Name of the vault configuration"
@@ -37,8 +30,14 @@ spec:
                   maxLength: 63
                 clusterName:
                   type: string
-                  description: "Crossplane provider config reference for target cluster"
+                  description: "Target cluster name (used for resource naming suffixes)"
                   default: "default"
+                providerConfigName:
+                  type: string
+                  description: "Name of the provider-helm / provider-kubernetes ProviderConfig. Defaults to clusterName."
+                namespace:
+                  type: string
+                  description: "Namespace that composed Release/Object resources are created in. Defaults to the VaultConfig's own metadata.namespace."
 
                 # Service Enablement Flags
                 csiEnabled:
@@ -52,6 +51,10 @@ spec:
                 esoEnabled:
                   type: boolean
                   description: "Enable External Secrets Operator"
+                  default: false
+                isVcluster:
+                  type: boolean
+                  description: "Disable liveness/readiness probes on ESO (vcluster-friendly)"
                   default: false
 
                 # Chart Versions
@@ -68,30 +71,30 @@ spec:
                 esoChartVersion:
                   type: string
                   description: "Chart version for External Secrets Operator"
-                  default: "0.20.3"
+                  default: "0.11.3"
                   pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
 
-                # Namespace Configuration
+                # Chart install namespaces (forProvider.namespace on each Helm Release)
                 namespaceCsi:
                   type: string
-                  description: "Namespace for Secrets Store CSI Driver"
+                  description: "Chart install namespace for Secrets Store CSI Driver"
                   default: "secrets-store-csi"
                   pattern: "^[a-z0-9-]+$"
                 namespaceVso:
                   type: string
-                  description: "Namespace for Vault Secrets Operator"
+                  description: "Chart install namespace for Vault Secrets Operator"
                   default: "vault-secrets-operator"
                   pattern: "^[a-z0-9-]+$"
                 namespaceEso:
                   type: string
-                  description: "Namespace for External Secrets Operator"
+                  description: "Chart install namespace for External Secrets Operator"
                   default: "external-secrets"
                   pattern: "^[a-z0-9-]+$"
 
                 # Kubernetes Auth Configuration
                 k8sAuths:
                   type: array
-                  description: "Kubernetes authentication configurations"
+                  description: "Kubernetes ServiceAccount + token Secret + auth-delegator binding to bootstrap per Vault Kubernetes auth backend"
                   items:
                     type: object
                     properties:
@@ -101,87 +104,18 @@ spec:
                         pattern: "^[a-z0-9-]+$"
                       namespace:
                         type: string
-                        description: "Namespace for the auth resources"
+                        description: "Namespace of the ServiceAccount + Secret + CRB target"
                         default: "default"
                         pattern: "^[a-z0-9-]+$"
                     required:
                       - name
-                  default:
-                    - name: "vault-auth-default"
-                      namespace: "default"
-
-                # Connection Secret Configuration
-                connectionSecret:
-                  type: object
-                  description: "Connection secret configuration"
-                  properties:
-                    enabled:
-                      type: boolean
-                      description: "Enable connection secret creation"
-                      default: true
-                    name:
-                      type: string
-                      description: "Name of the connection secret"
-                    namespace:
-                      type: string
-                      description: "Namespace for connection secret"
-                      default: "crossplane-system"
-                  default:
-                    enabled: true
-                    namespace: "crossplane-system"
-
               required:
                 - name
                 - clusterName
-
             status:
               type: object
+              description: "Observed state of the VaultConfig."
               properties:
-                ready:
-                  type: boolean
-                  description: "Indicates if all vault services are ready"
-                conditions:
-                  type: array
-                  description: "Detailed status of each service"
-                  items:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      status:
-                        type: string
-                      reason:
-                        type: string
-                      message:
-                        type: string
-                servicesStatus:
+                share:
                   type: object
-                  description: "Status of individual vault services"
-                  properties:
-                    csi:
-                      type: object
-                      properties:
-                        enabled:
-                          type: boolean
-                        ready:
-                          type: boolean
-                        namespace:
-                          type: string
-                    vso:
-                      type: object
-                      properties:
-                        enabled:
-                          type: boolean
-                        ready:
-                          type: boolean
-                        namespace:
-                          type: string
-                    eso:
-                      type: object
-                      properties:
-                        enabled:
-                          type: boolean
-                        ready:
-                          type: boolean
-                        namespace:
-                          type: string
+                  x-kubernetes-preserve-unknown-fields: true

--- a/configurations/bootstrap/vault-config/examples/claim.yaml
+++ b/configurations/bootstrap/vault-config/examples/claim.yaml
@@ -1,37 +1,38 @@
 ---
 apiVersion: config.stuttgart-things.com/v1alpha1
-kind: XVaultConfig
+kind: VaultConfig
 metadata:
-  name: vault-config-example
-  namespace: crossplane-system
+  name: vault-config
+  namespace: default
 spec:
-  name: vault-config-test
-  clusterName: "k3s-prod"
+  name: vault-config
+  clusterName: vcluster-tink2
 
-  # Enable all services for comprehensive testing
+  # Name of the provider-helm / provider-kubernetes ProviderConfig on the
+  # target cluster. Defaults to clusterName if unset.
+  providerConfigName: default
+
+  # Service enablement
   csiEnabled: true
   vsoEnabled: true
   esoEnabled: true
+  # isVcluster: true  # disable ESO probes if running inside a vcluster
 
-  # Use specific chart versions
+  # Chart versions
   csiChartVersion: "1.5.4"
   vsoChartVersion: "1.0.1"
-  esoChartVersion: "0.20.3"
+  esoChartVersion: "0.11.3"
 
-  # Custom namespaces
-  namespaceCsi: "secrets-store-csi"
-  namespaceVso: "vault-secrets-operator"
-  namespaceEso: "external-secrets-system"
+  # Chart install namespaces
+  namespaceCsi: secrets-store-csi
+  namespaceVso: vault-secrets-operator
+  namespaceEso: external-secrets
 
-  # Kubernetes Auth configurations
+  # ServiceAccount + token Secret + auth-delegator CRB bootstrap
+  # (one per k8sAuth entry — the name here should match the role/auth path
+  # created by xplane-vault-auth for this cluster)
   k8sAuths:
-    - name: "vault-auth-apps"
-      namespace: "applications"
-    - name: "vault-auth-platform"
-      namespace: "platform-system"
-
-  # Connection secret configuration
-  connectionSecret:
-    enabled: true
-    name: "vault-config-connection"
-    namespace: "crossplane-system"
+    - name: dev
+      namespace: default
+    - name: cicd
+      namespace: default

--- a/configurations/bootstrap/vault-config/examples/development.yaml
+++ b/configurations/bootstrap/vault-config/examples/development.yaml
@@ -15,7 +15,7 @@ spec:
 
   # Use latest stable versions
   csiChartVersion: "1.5.4"
-  esoChartVersion: "0.20.3"
+  esoChartVersion: "0.11.3"
 
   # Development namespaces
   namespaceCsi: "secrets-csi"
@@ -25,13 +25,3 @@ spec:
   k8sAuths:
     - name: "vault-auth-dev"
       namespace: "development"
-
-  # Development connection secret
-  connectionSecret:
-    enabled: true
-    name: "vault-config-dev-connection"
-    namespace: "development"
-
-writeConnectionSecretToRef:
-  name: vault-dev-secrets
-  namespace: development

--- a/configurations/bootstrap/vault-config/examples/functions.yaml
+++ b/configurations/bootstrap/vault-config/examples/functions.yaml
@@ -4,4 +4,11 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-kcl
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.9.0
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.12.1
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: crossplane-contrib-function-auto-ready
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.0

--- a/configurations/bootstrap/vault-config/examples/production.yaml
+++ b/configurations/bootstrap/vault-config/examples/production.yaml
@@ -16,7 +16,7 @@ spec:
   # Production-tested versions
   csiChartVersion: "1.5.4"
   vsoChartVersion: "1.0.1"
-  esoChartVersion: "0.20.3"
+  esoChartVersion: "0.11.3"
 
   # Production namespaces following security standards
   namespaceCsi: "vault-csi-system"
@@ -33,13 +33,3 @@ spec:
       namespace: "monitoring-system"
     - name: "vault-auth-security"
       namespace: "security-system"
-
-  # Production connection secret
-  connectionSecret:
-    enabled: true
-    name: "vault-config-prod-connection"
-    namespace: "crossplane-system"
-
-writeConnectionSecretToRef:
-  name: vault-production-secrets
-  namespace: production


### PR DESCRIPTION
## Summary
Rework the `vault-config` bootstrap configuration to match the v2 namespaced pattern established in `vault-auth`, and consume `xplane-vault-config:0.4.0`.

- **XRD** → `apiextensions.crossplane.io/v2`, `scope: Namespaced`, drops `claimNames`. Composite kind renamed from `XVaultConfig` to `VaultConfig` to match the existing example files and the sibling vault-auth style.
- **XRD spec**: add `providerConfigName` + `namespace` fields; drop the `connectionSecret` block (not wired into the KCL module).
- **Composition**: target new `VaultConfig` kind, use `KCLInput` (not deprecated `KCLRun`), bump source to `xplane-vault-config:0.4.0`, add the `function-auto-ready` step.
- **Examples**: drop `connectionSecret` / `writeConnectionSecretToRef`, align ESO chart to `0.11.3`, refresh `claim.yaml` with `providerConfigName` + realistic `k8sAuths`.
- **functions.yaml**: bump `function-kcl` to `v0.12.1` and add `function-auto-ready:v0.4.0`.

## Test plan
- [x] `crossplane render examples/claim.yaml apis/composition.yaml examples/functions.yaml` — every composed `Release` / `Object` lands in the XR's `metadata.namespace` and `providerConfigRef.name` honors `spec.providerConfigName`
- [ ] Apply XRD + composition against a k3s cluster with `function-kcl:v0.12.1`
- [ ] Apply `examples/claim.yaml` as a namespaced `VaultConfig` and confirm `Synced=True, Ready=True`

Generated with [Claude Code](https://claude.com/claude-code)