### PR TITLE
feat(vault-config): bump xplane-vault-config KCL module to 0.5.0

### DIFF
--- a/configurations/bootstrap/vault-config/README.md
+++ b/configurations/bootstrap/vault-config/README.md
@@ -202,6 +202,13 @@ kubectl get deployment -n external-secrets-system
 |-----------|------|---------|-------------|
 | `k8sAuths` | array | `[{"name": "vault-auth-default", "namespace": "default"}]` | Kubernetes auth configurations |
 
+### Provider Config
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `providerConfigName` | string | `clusterName` | Name of the provider-helm / provider-kubernetes ProviderConfig on the target cluster. Defaults to `clusterName` if unset. |
+| `providerConfigKind` | string | `"ClusterProviderConfig"` | Kind of the ProviderConfig referenced by composed MRs. Must be `ClusterProviderConfig` or `ProviderConfig`. Namespaced v2 MRs (as used by `xplane-vault-config` >= 0.5.0) typically consume a cluster-scoped `ClusterProviderConfig`. |
+
 ### Connection Secrets
 
 | Parameter | Type | Default | Description |
@@ -436,7 +443,7 @@ kubectl describe secret VAULT_CONFIG_NAME-connection -n crossplane-system
 - **KCL Function**: `xpkg.upbound.io/crossplane-contrib/function-kcl:>=v0.9.0`
 - **Stuttgart-Things Helm Provider**: `ghcr.io/stuttgart-things/crossplane-provider-helm:>=v0.1.1`
 - **Kubernetes Provider**: `xpkg.upbound.io/crossplane-contrib/provider-kubernetes:>=v0.18.0`
-- **KCL Module**: `oci://ghcr.io/stuttgart-things/xplane-vault-config:0.1.0`
+- **KCL Module**: `oci://ghcr.io/stuttgart-things/xplane-vault-config:0.5.0`
 - **Docker**: Required for KCL function runtime during testing
 
 ## Integration Examples

--- a/configurations/bootstrap/vault-config/apis/composition.yaml
+++ b/configurations/bootstrap/vault-config/apis/composition.yaml
@@ -23,7 +23,7 @@ spec:
         metadata:
           name: vault-config
         spec:
-          source: oci://ghcr.io/stuttgart-things/xplane-vault-config:0.4.0
+          source: oci://ghcr.io/stuttgart-things/xplane-vault-config:0.5.0
     - step: automatically-detect-ready-composed-resources
       functionRef:
         name: crossplane-contrib-function-auto-ready

--- a/configurations/bootstrap/vault-config/apis/definition.yaml
+++ b/configurations/bootstrap/vault-config/apis/definition.yaml
@@ -35,6 +35,13 @@ spec:
                 providerConfigName:
                   type: string
                   description: "Name of the provider-helm / provider-kubernetes ProviderConfig. Defaults to clusterName."
+                providerConfigKind:
+                  type: string
+                  description: "Kind of the ProviderConfig referenced by composed MRs. Namespaced v2 MRs typically consume a cluster-scoped ClusterProviderConfig."
+                  default: "ClusterProviderConfig"
+                  enum:
+                    - ClusterProviderConfig
+                    - ProviderConfig
                 namespace:
                   type: string
                   description: "Namespace that composed Release/Object resources are created in. Defaults to the VaultConfig's own metadata.namespace."


### PR DESCRIPTION
## Summary
- Bump composition source from `xplane-vault-config:0.4.0` → `0.5.0`
- Add `providerConfigKind` field to the VaultConfig XRD (default `ClusterProviderConfig`, enum `ClusterProviderConfig`/`ProviderConfig`) to match the v0.5.0 module's v2 namespaced MR provider ref handling

## Test plan
- [x] `crossplane render examples/claim.yaml apis/composition.yaml examples/functions.yaml` produces the XR plus 14 composed resources with `providerConfigRef.kind: ClusterProviderConfig`
- [x] `kcl run main.k` against the upstream module renders cleanly with the example params

Generated with [Claude Code](https://claude.com/claude-code)