### PR TITLE
docs(vault-config): document providerConfigKind and bump KCL module reference

### DIFF
--- a/configurations/bootstrap/vault-config/README.md
+++ b/configurations/bootstrap/vault-config/README.md
@@ -202,6 +202,13 @@ kubectl get deployment -n external-secrets-system
 |-----------|------|---------|-------------|
 | `k8sAuths` | array | `[{"name": "vault-auth-default", "namespace": "default"}]` | Kubernetes auth configurations |
 
+### Provider Config
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `providerConfigName` | string | `clusterName` | Name of the provider-helm / provider-kubernetes ProviderConfig on the target cluster. Defaults to `clusterName` if unset. |
+| `providerConfigKind` | string | `"ClusterProviderConfig"` | Kind of the ProviderConfig referenced by composed MRs. Must be `ClusterProviderConfig` or `ProviderConfig`. Namespaced v2 MRs (as used by `xplane-vault-config` >= 0.5.0) typically consume a cluster-scoped `ClusterProviderConfig`. |
+
 ### Connection Secrets
 
 | Parameter | Type | Default | Description |
@@ -436,7 +443,7 @@ kubectl describe secret VAULT_CONFIG_NAME-connection -n crossplane-system
 - **KCL Function**: `xpkg.upbound.io/crossplane-contrib/function-kcl:>=v0.9.0`
 - **Stuttgart-Things Helm Provider**: `ghcr.io/stuttgart-things/crossplane-provider-helm:>=v0.1.1`
 - **Kubernetes Provider**: `xpkg.upbound.io/crossplane-contrib/provider-kubernetes:>=v0.18.0`
-- **KCL Module**: `oci://ghcr.io/stuttgart-things/xplane-vault-config:0.1.0`
+- **KCL Module**: `oci://ghcr.io/stuttgart-things/xplane-vault-config:0.5.0`
 - **Docker**: Required for KCL function runtime during testing
 
 ## Integration Examples


### PR DESCRIPTION
## Summary
Docs-only follow-up to #70. The PR only touches `apis/` but leaves the README inconsistent with the XRD and composition changes.

- Add a new **Provider Config** subsection under *Configuration Options* in `configurations/bootstrap/vault-config/README.md` documenting:
  - `providerConfigName` (was previously undocumented)
  - the new `providerConfigKind` field (default `ClusterProviderConfig`, enum `ClusterProviderConfig`/`ProviderConfig`) introduced with `xplane-vault-config` 0.5.0 for v2 namespaced MR provider ref handling
- Bump the stale KCL module reference in the *Dependencies* section: `oci://ghcr.io/stuttgart-things/xplane-vault-config:0.1.0` → `0.5.0` (matches `apis/composition.yaml`)

## Not changed (intentional)
- `examples/claim.yaml`, `examples/development.yaml`, `examples/production.yaml` — the new field is optional with a sensible default, so existing examples still render correctly and don't need updates. Forcing `providerConfigKind` into every example would just be noise.

## Test plan
- [x] README renders correctly on GitHub
- [x] Confirmed `apis/composition.yaml` already uses `xplane-vault-config:0.5.0` so the new dependency reference is accurate
- [x] No code changes, so `crossplane render` behavior from #70 is unaffected

Stacked on top of #70.

Generated with [Claude Code](https://claude.com/claude-code)